### PR TITLE
IS-6 PoC of alternative scenario syntax

### DIFF
--- a/StoryLine.Selenium.Runner/GuidGenerator/Actions/GenerateGuids.cs
+++ b/StoryLine.Selenium.Runner/GuidGenerator/Actions/GenerateGuids.cs
@@ -4,6 +4,7 @@ using StoryLine.Contracts;
 using StoryLine.Selenium.Actions;
 using StoryLine.Selenium.Runner.GuidGenerator.Models;
 using StoryLine.Selenium.Runner.GuidGenerator.Pages;
+using StoryLine.Selenium.Runner.Helpers;
 using StoryLine.Utils.Expectations;
 
 namespace StoryLine.Selenium.Runner.GuidGenerator.Actions
@@ -32,16 +33,23 @@ namespace StoryLine.Selenium.Runner.GuidGenerator.Actions
             if (actor == null)
                 throw new ArgumentNullException(nameof(actor));
 
-            Scenario.New()
-                .Given(actor)
-                    .HasPerformed<Navigate>(x => x.Url("https://www.guidgenerator.com/"))
-                    .HasPerformed<SetModel>(x => x.Data(new MainPageModel { Count = _guidCount }))
-                .When()
-                    .Performs<Click>(x => x.Element(MainPage.GenerateButton))
-                    .Performs<GetModel>(x => x.Type<MainPageModel>())
-                .Then()
-                    .Expects<Artifact<MainPageModel>>(x => x.Meets(p => p.Results.Length > 0))
-                .Run();
+            //Scenario.New()
+            //    .Given(actor)
+            //        .HasPerformed<Navigate>(x => x.Url("https://www.guidgenerator.com/"))
+            //        .HasPerformed<SetModel>(x => x.Data(new MainPageModel { Count = _guidCount }))
+            //    .When()
+            //        .Performs<Click>(x => x.Element(MainPage.GenerateButton))
+            //        .Performs<GetModel>(x => x.Type<MainPageModel>())
+            //    .Then()
+            //        .Expects<Artifact<MainPageModel>>(x => x.Meets(p => p.Results.Length > 0))
+            //    .Run();
+
+            actor
+                .NavigatesTo("https://www.guidgenerator.com/")
+                .Sets(new MainPageModel { Count = _guidCount })
+                .Clicks(MainPage.GenerateButton)
+                .Gets<MainPageModel>()
+                .ExpectsArtifact<MainPageModel>(x => x.Results.Length > 0);
         }
     }
 }

--- a/StoryLine.Selenium.Runner/Helpers/ActorExtensions.cs
+++ b/StoryLine.Selenium.Runner/Helpers/ActorExtensions.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using StoryLine.Contracts;
+using StoryLine.Utils.Expectations;
+
+namespace StoryLine.Selenium.Runner.Helpers
+{
+    public static class ActorExtensions
+    {
+        public static IActor Does<TActionBuilder>(this IActor actor, Action<TActionBuilder> config)
+            where TActionBuilder : IActionBuilder, new()
+        {
+            if (actor == null)
+                throw new ArgumentNullException(nameof(actor));
+            if (config == null)
+                throw new ArgumentNullException(nameof(config));
+
+            Scenario.New()
+                .When(actor)
+                    .Performs(config)
+                .Run();
+
+            return actor;
+        }
+
+        public static IActor Does<TActionBuilder, TArtifact1>(this IActor actor, Action<TActionBuilder, TArtifact1> config, Func<TArtifact1, bool> predicate1 = null)
+            where TActionBuilder : IActionBuilder, new()
+        {
+            if (actor == null)
+                throw new ArgumentNullException(nameof(actor));
+            if (config == null)
+                throw new ArgumentNullException(nameof(config));
+
+            Scenario.New()
+                .When(actor)
+                    .Performs(config, predicate1)
+                .Run();
+
+            return actor;
+        }
+
+        public static IActor Expects<TExpectationBuilder>(this IActor actor, Action<TExpectationBuilder> config)
+            where TExpectationBuilder : IExpectationBuilder, new()
+        {
+            if (actor == null)
+                throw new ArgumentNullException(nameof(actor));
+            if (config == null)
+                throw new ArgumentNullException(nameof(config));
+
+            Scenario.New()
+                .When(actor)
+                    .Performs<Nothing>()
+                .Then()
+                    .Expects(config)
+                .Run();
+
+            return actor;
+        }
+
+        public static IActor ExpectsArtifact<TArtifact>(this IActor actor, Func<TArtifact, bool> predicate)
+        {
+            if (actor == null)
+                throw new ArgumentNullException(nameof(actor));
+            if (predicate == null)
+                throw new ArgumentNullException(nameof(predicate));
+
+            Scenario.New()
+                .When(actor)
+                    .Performs<Nothing>()
+                .Then()
+                    .Expects<Artifact<TArtifact>>(x => x.Meets(predicate))
+                .Run();
+
+            return actor;
+        }
+
+        public static IActor ExpectsArtifact<TArtifact>(this IActor actor, Action<TArtifact> assertion)
+        {
+            if (actor == null)
+                throw new ArgumentNullException(nameof(actor));
+            if (assertion == null)
+                throw new ArgumentNullException(nameof(assertion));
+
+            Scenario.New()
+                .When(actor)
+                    .Performs<Nothing>()
+                .Then()
+                    .Expects<Artifact<TArtifact>>(x => x.Meets(assertion))
+                .Run();
+
+            return actor;
+        }
+
+        private class Nothing : IActionBuilder, IAction
+        {
+            public IAction Build()
+            {
+                return this;
+            }
+
+            public void Execute(IActor actor)
+            {
+            }
+        }
+    }
+}

--- a/StoryLine.Selenium.Runner/Helpers/Aliases.cs
+++ b/StoryLine.Selenium.Runner/Helpers/Aliases.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using StoryLine.Contracts;
+using StoryLine.Selenium.Actions;
+using StoryLine.Selenium.Selectors;
+
+namespace StoryLine.Selenium.Runner.Helpers
+{
+    public static class Aliases
+    {
+        public static IActor NavigatesTo(this IActor actor, string url)
+        {
+            if (actor == null)
+                throw new ArgumentNullException(nameof(actor));
+            if (url == null)
+                throw new ArgumentNullException(nameof(url));
+
+            return actor.Does<Navigate>(x => x.Url(url));
+        }
+
+        public static IActor Clicks(this IActor actor, IElementSelector selector)
+        {
+            if (actor == null)
+                throw new ArgumentNullException(nameof(actor));
+            if (selector == null)
+                throw new ArgumentNullException(nameof(selector));
+
+            return actor.Does<Click>(x => x.Element(selector));
+        }
+
+        public static IActor Sets<TModel>(this IActor actor, TModel data)
+        {
+            if (actor == null)
+                throw new ArgumentNullException(nameof(actor));
+
+            return actor.Does<SetModel>(x => x.Data(data));
+        }
+
+        public static IActor Gets<TModel>(this IActor actor)
+        {
+            if (actor == null)
+                throw new ArgumentNullException(nameof(actor));
+
+            return actor.Does<GetModel>(x => x.Type<TModel>());
+        }
+    }
+}


### PR DESCRIPTION
PoC of alternative scenario syntax. Scenarios can be implemented as follows:
```
            actor
                .NavigatesTo("https://www.guidgenerator.com/")
                .Sets(new MainPageModel { Count = _guidCount })
                .Clicks(MainPage.GenerateButton)
                .Gets<MainPageModel>()
                .ExpectsArtifact<MainPageModel>(x => x.Results.Length > 0);
```
Alternatively you still can do the following:
```
            actor
                .Does<Navigate>(x => x.Url("https://www.guidgenerator.com/"))
                .Does<SetModel>(x => x.Data(new MainPageModel { Count = _guidCount }))
                .Does<Click>(x => x.Element(MainPage.GenerateButton))
                .Does<GetModel>(x => x.Type<MainPageModel>())
                .ExpectsArtifact<MainPageModel>(x => x.Results.Length > 0);
```
Aliases are expected to be used for constructions which repeats in many places. They are not expected to store any logic. 
**IMPORANT: The only purpose of aliases is to type less code.**